### PR TITLE
🔧 Migrate omo [opencode] config to reasoning-unification format

### DIFF
--- a/home-manager/cli/dev/omo/default.nix
+++ b/home-manager/cli/dev/omo/default.nix
@@ -43,9 +43,9 @@ let
         "model-version:openai/gpt-5.4->openai/gpt-5.5"
       ];
     };
-    # Pin both migration markers: senpi-base.nix is already in the
-    # post-reasoning-unification format, and re-running the migration would
-    # just rewrite the managed file at runtime.
+    # Pin both migration markers: senpi-base.nix and opencode-base.nix are
+    # already in the post-reasoning-unification format, and re-running the
+    # migration would just rewrite the managed file at runtime.
     _migrations = [
       "2026-07-opencode-config-unification"
       "2026-08-reasoning-unification"

--- a/home-manager/cli/dev/omo/opencode-base.nix
+++ b/home-manager/cli/dev/omo/opencode-base.nix
@@ -3,108 +3,125 @@
 # (oh-my-openagent-go.json).
 #
 # Notes:
+# - Uses the post-2026-08-reasoning-unification format (`models` list with
+#   `reasoning` entries); the migration marker is pinned in ./default.nix, so
+#   reintroducing `fallback_models`/`variant` makes `omo doctor` flag this file.
 # - `skills.sources` is injected in ./default.nix (needs configDir).
 # - Per-host overrides are deep-merged via packs.opencode.omoOverrides
 #   (see module/opencode).
 {
   agents = {
     sisyphus = {
-      model = "cli-proxy-api/kimi-k3";
-      fallback_models = [
+      models = [
+        "cli-proxy-api/kimi-k3"
         { model = "cli-proxy-api/kimi-k2.7-code"; }
         {
           model = "cli-proxy-api/gpt-5.6-luna";
-          variant = "ultra";
+          reasoning = "ultra";
         }
       ];
     };
     hephaestus = {
-      model = "cli-proxy-api/gpt-5.6-sol";
-      variant = "medium";
-      fallback_models = [
+      models = [
+        {
+          model = "cli-proxy-api/gpt-5.6-sol";
+          reasoning = "medium";
+        }
         {
           model = "cli-proxy-api/deepseek-v4-pro";
-          variant = "max";
+          reasoning = "max";
         }
       ];
     };
     oracle = {
-      model = "cli-proxy-api/gpt-5.6-sol";
-      variant = "xhigh";
-      fallback_models = [
+      models = [
+        {
+          model = "cli-proxy-api/gpt-5.6-sol";
+          reasoning = "xhigh";
+        }
         {
           model = "cli-proxy-api/gpt-5.6-terra";
-          variant = "max";
+          reasoning = "max";
         }
       ];
     };
     momus = {
-      model = "cli-proxy-api/gpt-5.6-sol";
-      variant = "xhigh";
-      fallback_models = [
+      models = [
+        {
+          model = "cli-proxy-api/gpt-5.6-sol";
+          reasoning = "xhigh";
+        }
         {
           model = "cli-proxy-api/gpt-5.6-terra";
-          variant = "max";
+          reasoning = "max";
         }
       ];
     };
     metis = {
-      model = "cli-proxy-api/gpt-5.6-sol";
-      variant = "xhigh";
-      fallback_models = [
+      models = [
+        {
+          model = "cli-proxy-api/gpt-5.6-sol";
+          reasoning = "xhigh";
+        }
         {
           model = "cli-proxy-api/gpt-5.6-terra";
-          variant = "max";
+          reasoning = "max";
         }
         {
           model = "cli-proxy-api/glm-5.2";
-          variant = "max";
+          reasoning = "max";
         }
       ];
     };
     prometheus = {
-      model = "cli-proxy-api/gpt-5.6-sol";
-      variant = "xhigh";
-      fallback_models = [
+      models = [
+        {
+          model = "cli-proxy-api/gpt-5.6-sol";
+          reasoning = "xhigh";
+        }
         {
           model = "cli-proxy-api/glm-5.2";
-          variant = "max";
+          reasoning = "max";
         }
       ];
     };
     atlas = {
-      model = "cli-proxy-api/kimi-k3";
-      fallback_models = [
+      models = [
+        "cli-proxy-api/kimi-k3"
         { model = "cli-proxy-api/kimi-k2.7-code"; }
       ];
     };
     sisyphus-junior = {
-      model = "openrouter/kimi-k3";
-      fallback_models = [
+      models = [
+        "openrouter/kimi-k3"
         { model = "cli-proxy-api/kimi-k2.7-code"; }
         {
           model = "cli-proxy-api/glm-5.2";
-          variant = "max";
+          reasoning = "max";
         }
       ];
     };
     explore = {
-      model = "cli-proxy-api/glm-5.2";
-      variant = "max";
-      fallback_models = [
+      models = [
+        {
+          model = "cli-proxy-api/glm-5.2";
+          reasoning = "max";
+        }
         {
           model = "cli-proxy-api/gpt-5.6-luna";
-          variant = "medium";
+          reasoning = "medium";
         }
       ];
     };
     librarian = {
-      model = "cli-proxy-api/glm-5.2";
-      variant = "max";
-      fallback_models = [
+      models = [
+        {
+          model = "cli-proxy-api/glm-5.2";
+          reasoning = "max";
+        }
         {
           model = "cli-proxy-api/gpt-5.6-luna";
-          variant = "medium";
+          reasoning = "medium";
         }
       ];
     };
@@ -114,64 +131,73 @@
   };
   categories = {
     visual-engineering = {
-      model = "CrofAI/greg-2-super";
-      fallback_models = [
+      models = [
+        "CrofAI/greg-2-super"
         { model = "cli-proxy-api/kimi-k2.7-code"; }
         {
           model = "cli-proxy-api/glm-5.2";
-          variant = "max";
+          reasoning = "max";
         }
       ];
     };
     ultrabrain = {
-      model = "cli-proxy-api/gpt-5.6-sol";
-      variant = "xhigh";
-      fallback_models = [
+      models = [
+        {
+          model = "cli-proxy-api/gpt-5.6-sol";
+          reasoning = "xhigh";
+        }
         {
           model = "cli-proxy-api/deepseek-v4-pro";
-          variant = "max";
+          reasoning = "max";
         }
       ];
     };
     deep = {
-      model = "cli-proxy-api/gpt-5.6-sol";
-      variant = "high";
-      fallback_models = [
+      models = [
+        {
+          model = "cli-proxy-api/gpt-5.6-sol";
+          reasoning = "high";
+        }
         {
           model = "cli-proxy-api/glm-5.2";
-          variant = "max";
+          reasoning = "max";
         }
       ];
     };
     artistry = {
-      model = "cli-proxy-api/gpt-5.6-sol";
-      variant = "xhigh";
-      fallback_models = [
+      models = [
+        {
+          model = "cli-proxy-api/gpt-5.6-sol";
+          reasoning = "xhigh";
+        }
         {
           model = "cli-proxy-api/deepseek-v4-pro";
-          variant = "max";
+          reasoning = "max";
         }
       ];
     };
     quick = {
-      model = "cli-proxy-api/deepseek-v4-flash";
-      variant = "max";
-      fallback_models = [
+      models = [
+        {
+          model = "cli-proxy-api/deepseek-v4-flash";
+          reasoning = "max";
+        }
         { model = "cli-proxy-api/kimi-k2.7-code"; }
       ];
     };
     unspecified-low = {
-      model = "cli-proxy-api/glm-5.2";
-      variant = "max";
-      fallback_models = [ ];
+      models = [
+        {
+          model = "cli-proxy-api/glm-5.2";
+          reasoning = "max";
+        }
+      ];
     };
     unspecified-high = {
-      model = "cli-proxy-api/kimi-k3";
-      fallback_models = [ ];
+      models = [ "cli-proxy-api/kimi-k3" ];
     };
     writing = {
-      model = "cli-proxy-api/kimi-k2.7-code";
-      fallback_models = [ ];
+      models = [ "cli-proxy-api/kimi-k2.7-code" ];
     };
   };
   tmux = {
@@ -189,8 +215,6 @@
       CrofAI = 20;
     };
     circuitBreaker = {
-      windowSize = 100;
-      repetitionThresholdPercent = 90;
       maxToolCalls = 400;
     };
   };


### PR DESCRIPTION
## Summary

`omo doctor` reported 34 issues. This PR fixes the config-source-of-truth (`opencode-base.nix`) and the live `~/.omo/omo.jsonc` for all issues addressable from this repo.

### Fixes

| Issue | Fix |
|-------|-----|
| Invalid `background_task.circuitBreaker.windowSize` / `repetitionThresholdPercent` | Removed — schema is `additionalProperties: false` (only `enabled`, `maxToolCalls`, `consecutiveThreshold` are valid) |
| Deprecated `fallback_models` (agents + categories) | Migrated to `models` list — matches `omo config migrate` canonical output |
| Deprecated `variant` (agents + categories) | Migrated to `reasoning` — matches `omo config migrate` canonical output |
| Plugin outdated (4.19.3 → 4.19.4) | Updated via `bun add oh-my-openagent@latest` in the plugin cache (outside this repo) |

### Approach

- Captured the canonical post-migration format by running `omo config migrate --dry-run --json` (with the pinned `_migrations` marker temporarily stripped) to get ground-truth output from the plugin itself.
- Rewrote `opencode-base.nix` to match that output exactly (verified via `nix eval` — generated JSON matches canonical migration transform byte-for-byte, modulo the removed invalid circuitBreaker keys).
- `senpi-base.nix` was already in this format; `opencode-base.nix` is now aligned.
- Updated the `default.nix` comment to reflect that both base files are now post-reasoning-unification.

### Remaining doctor warnings (not fixable in this repo)

After this fix, `omo doctor` on 4.19.4 reports 10 `Unknown config key: agents.<name>.models` warnings for `[opencode]` agents. This is a 4.19.4 internal inconsistency: the plugin's own `config migrate` produces `models` for agents, and the published JSON schema (`omo.schema.json` dev branch) accepts it, but the released 4.19.4 `AgentOverrideConfigSchema` (used by doctor's unknown-key check) hasn't been updated to include `models` for agents yet (categories already accept it). The dev-branch schema already has the fix, so the next release should resolve this.

### Verification

- `nix eval` of the new `opencode-base.nix` matches the canonical migration transform.
- `nix fmt` — 0 changes (formatting clean).
- `omo doctor` — reduced from 34 issues to 11 (10 false-positive unknown-key + 1 LSP-not-detected).
- Live `~/.omo/omo.jsonc` applied and verified.