### PR TITLE
🐛 Retry attic push with backoff in CI builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -174,7 +174,19 @@ jobs:
           PACKAGE: ${{ matrix.packages }}
       - name: Push to attic
         if: success()
-        run: attic push home ./result
+        run: |
+          # tailscaled ingress stalls under concurrent large uploads (issue #72); retry with backoff
+          for attempt in 1 2 3; do
+            if attic push home ./result; then
+              exit 0
+            fi
+            if [ "$attempt" -lt 3 ]; then
+              delay=$((attempt * 30 + RANDOM % 30))
+              echo "attic push failed (attempt $attempt/3); retrying in ${delay}s"
+              sleep "$delay"
+            fi
+          done
+          exit 1
   build-darwin:
     name: Build packages on Mac
     runs-on: macos-latest
@@ -223,7 +235,19 @@ jobs:
           PACKAGE: ${{ matrix.packages }}
       - name: Push to attic
         if: success()
-        run: attic push home ./result
+        run: |
+          # tailscaled ingress stalls under concurrent large uploads (issue #72); retry with backoff
+          for attempt in 1 2 3; do
+            if attic push home ./result; then
+              exit 0
+            fi
+            if [ "$attempt" -lt 3 ]; then
+              delay=$((attempt * 30 + RANDOM % 30))
+              echo "attic push failed (attempt $attempt/3); retrying in ${delay}s"
+              sleep "$delay"
+            fi
+          done
+          exit 1
   build-rocm-base:
     name: Build ROCm base packages on Linux
     runs-on: ubuntu-latest
@@ -272,7 +296,18 @@ jobs:
           nix build --fallback --no-link --print-out-paths ".#$PACKAGE" > "$paths_file"
           mapfile -t paths < "$paths_file"
           (( ${#paths[@]} > 0 ))
-          attic push home "${paths[@]}"
+          # tailscaled ingress stalls under concurrent large uploads (issue #72); retry with backoff
+          for attempt in 1 2 3; do
+            if attic push home "${paths[@]}"; then
+              exit 0
+            fi
+            if [ "$attempt" -lt 3 ]; then
+              delay=$((attempt * 30 + RANDOM % 30))
+              echo "attic push failed (attempt $attempt/3); retrying in ${delay}s"
+              sleep "$delay"
+            fi
+          done
+          exit 1
         env:
           PACKAGE: ${{ matrix.packages }}
   build-downstream:
@@ -320,7 +355,18 @@ jobs:
           nix build --fallback --no-link --print-out-paths ".#$PACKAGE" > "$paths_file"
           mapfile -t paths < "$paths_file"
           (( ${#paths[@]} > 0 ))
-          attic push home "${paths[@]}"
+          # tailscaled ingress stalls under concurrent large uploads (issue #72); retry with backoff
+          for attempt in 1 2 3; do
+            if attic push home "${paths[@]}"; then
+              exit 0
+            fi
+            if [ "$attempt" -lt 3 ]; then
+              delay=$((attempt * 30 + RANDOM % 30))
+              echo "attic push failed (attempt $attempt/3); retrying in ${delay}s"
+              sleep "$delay"
+            fi
+          done
+          exit 1
         env:
           PACKAGE: ${{ matrix.packages }}
   all-workflows-passed:


### PR DESCRIPTION
## 概要

build-linux 等の matrix ジョブが同時に `attic push` する際、Tailscale Ingress プロキシ (ts-attic の tailscaled) の停滞で `Connection timed out (os error 110)` により失敗する問題への CI 側対策。上流未修正 (tailscale/tailscale#20109, #16198) のため push 側に耐性をつける。

- 4箇所の push (build-linux / build-darwin / build-rocm-base / build-downstream) を最大3回リトライ
- 指数バックオフ (30s→60s) + 最大30sのジッター。固定 wait だと同時に死んだ matrix ジョブが同時に再送してプロキシを再度詰まらせるため、ジッターで再同期を崩す
- 提案2 (push 集約ジョブ化): 数GBクロージャの artifact 転送が必要で非現実的なため不採用
- 提案3 (`--jobs` 絞り込み): attic push `-j` (default 5) は存在するが、健全時の単発 push が遅くなるだけで matrix 間の合計並行数は変わらないため不採用

## 検証

- スタブ attic (2回 ETIMEDOUT→3回目成功) でリトライ成功・常時失敗時は3回試行後 exit 1 を確認
- actionlint + YAML parse パス

Closes #72
